### PR TITLE
Allow users to associate themselves with multiple organizations

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -34,7 +34,7 @@ class TagsController < ApplicationController
   end
 
   def destroy_user_tag
-    if Tag::Destroy.call(params[:tag_id], nil, current_user)
+    if Tag::Destroy.call(params[:tag_id], current_user, current_user)
       flash[:success] = "The tag was successfully removed"
     else
       flash[:error] = "There was a problem removing your tag"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
-  def user_is_current_user?
-    (current_user.present? && @user == current_user)
+  def user_is_current_user?(user=@user)
+    (current_user.present? && user == current_user)
   end
 
   def organization_admin_user?

--- a/app/helpers/organizations_helper.rb
+++ b/app/helpers/organizations_helper.rb
@@ -6,15 +6,16 @@ module OrganizationsHelper
   def display_address
     address = ""
     if @organization.main_address.address1
-      address = "#{@organization.main_address.address1}, "
+      address = "#{@organization.main_address.address1}<br />"
     end
     if @organization.main_address.address2
-      address += "#{@organization.main_address.address2}, "
+      address += "#{@organization.main_address.address2}<br />"
     else
-      address += "#{Rails.application.secrets.location_name}, "
+      address += "#{Rails.application.secrets.location_name}<br />"
     end
     if @organization.main_address.zip
-      address += "#{@organization.main_address.zip}"
+      address += "#{@organization.main_address.zip}<br />"
     end
+    address.html_safe
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -17,8 +17,8 @@ class Organization < ActiveRecord::Base
   def search_data
     {
       name: name,
-      type_ids: types.map(&:id),
-      tag_names: tags.map(&:name)
+      type_ids: types.pluck(:id),
+      tag_names: tags.pluck(:name)
     }
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,4 +41,8 @@ class User < ActiveRecord::Base
   def self.create_access_token(user)
     verifier.generate(user.id)
   end
+
+  def is_admin?(organization)
+    id == organization.admin_id
+  end
 end

--- a/app/services/organization/claim.rb
+++ b/app/services/organization/claim.rb
@@ -11,6 +11,7 @@ class Organization::Claim
   def call
     if organization.update(claimed: true)
       organization.users << current_user
+      organization.update(admin_id: current_user.id)
       organization.create_activity key: "organization.claim", owner: current_user
     end
     organization

--- a/app/themes/weareyvr/assets/stylesheets/weareyvr/page.css.scss
+++ b/app/themes/weareyvr/assets/stylesheets/weareyvr/page.css.scss
@@ -111,7 +111,7 @@ a.remove-tag{
 }
 
 a.remove-role-org-page{
-  color: red;
+  color: red !important;
 }
 
 .check{
@@ -131,12 +131,19 @@ a.remove-role-org-page{
 }
 
 .person{
-  width: 200px;
+  width: 225px;
+  border: 1px solid #ccc;
   margin:5px;
+  padding:5px;
+  border-radius: 4px;
 }
 
 .person img{
   margin-right: 5px;
+}
+
+.chunk{
+  margin-bottom: 20px;
 }
 
 /*** Search Styles ***/

--- a/app/themes/weareyvr/assets/stylesheets/weareyvr/page.css.scss
+++ b/app/themes/weareyvr/assets/stylesheets/weareyvr/page.css.scss
@@ -130,7 +130,7 @@ a.remove-role-org-page{
   font-size: 18pt;
 }
 
-.person{
+.person, .role{
   width: 225px;
   border: 1px solid #ccc;
   margin:5px;
@@ -138,7 +138,7 @@ a.remove-role-org-page{
   border-radius: 4px;
 }
 
-.person img{
+.person img, .role img{
   margin-right: 5px;
 }
 

--- a/app/themes/weareyvr/assets/stylesheets/weareyvr/page.css.scss
+++ b/app/themes/weareyvr/assets/stylesheets/weareyvr/page.css.scss
@@ -57,6 +57,14 @@ div.submit{
 
 .claim-header{
   padding: 15px;
+  background-color: #10988b !important;
+  margin-bottom: 15px;
+  color: #FFF !important;
+}
+
+.claim-header a{
+  color: #FFF !important;
+  text-decoration: underline !important;
 }
 
 .small-field{
@@ -78,7 +86,6 @@ a.edit{
 
 #tags{
   margin-bottom: 15px;
-  height: 160px;
 }
 
 .tag{
@@ -103,6 +110,10 @@ a.remove-tag{
   text-decoration: none !important;
 }
 
+a.remove-role-org-page{
+  color: red;
+}
+
 .check{
   margin-left: 20px !important;
 }
@@ -117,6 +128,15 @@ a.remove-tag{
 
 .large-icon{
   font-size: 18pt;
+}
+
+.person{
+  width: 200px;
+  margin:5px;
+}
+
+.person img{
+  margin-right: 5px;
 }
 
 /*** Search Styles ***/

--- a/app/views/organizations/_claim_header.html.erb
+++ b/app/views/organizations/_claim_header.html.erb
@@ -1,5 +1,5 @@
 <% if not @organization.claimed? %>
-  <div class="bg-primary claim-header">
+  <div class="alert alert-info claim-header">
     This profile was generated via <%= link_to "Startup Genome", "http://startupgenome.com/", class: "bg-primary", target: "_blank" %>. If you would like to claim this profile, <%= link_to "click here", claim_organization_path(@organization), class: "bg-primary" %>.
   </div>
 <% end %>

--- a/app/views/organizations/_image.html.erb
+++ b/app/views/organizations/_image.html.erb
@@ -1,0 +1,9 @@
+<div class="header-image">
+  <% if @organization.image.present? %>
+    <%= image_tag @organization.image, height: "220" %>
+  <% elsif @organization.image.present? %>
+    <%= image_tag @organization.image, height: "220", class: "pull-left" %>
+  <% else %>
+    <span class="glyphicon glyphicon-user"></span>
+  <% end %>
+</div>

--- a/app/views/organizations/_profile_description.html.erb
+++ b/app/views/organizations/_profile_description.html.erb
@@ -1,4 +1,4 @@
 <h4>BUSINESS DESCRIPTION</h4>
-<p>
+<p class="chunk">
   <%= @organization.description %>
 </p>

--- a/app/views/organizations/_profile_description.html.erb
+++ b/app/views/organizations/_profile_description.html.erb
@@ -1,8 +1,4 @@
-<div class="row top-buffer">
-  <div class="col-sm-12">
-    <h4>BUSINESS DESCRIPTION</h4>
-    <p>
-      <%= @organization.description %>
-    </p>
-  </div>
-</div>
+<h4>BUSINESS DESCRIPTION</h4>
+<p>
+  <%= @organization.description %>
+</p>

--- a/app/views/organizations/_profile_header.html.erb
+++ b/app/views/organizations/_profile_header.html.erb
@@ -1,2 +1,2 @@
-<span class="big-text"><%= @organization.name %></span>
+<h4><%= @organization.name %></h4>
 <p><%= @organization.headline %></p>

--- a/app/views/organizations/_profile_header.html.erb
+++ b/app/views/organizations/_profile_header.html.erb
@@ -1,21 +1,2 @@
-<div class="col-sm-4">
-  <div class="header-image">
-    <% if @organization.image.present? %>
-      <%= image_tag @organization.image, height: "220" %>
-    <% elsif @organization.image.present? %>
-      <%= image_tag @organization.image, height: "220", class: "pull-left" %>
-    <% else %>
-      <span class="glyphicon glyphicon-user"></span>
-    <% end %>
-  </div>
-</div>
-<div class="col-sm-8">
-  <span class="big-text"><%= @organization.name %></span>
-  <p><%= @organization.headline %></p>
-  <% if @organization.main_address %>
-    <div class="pull-left"><%= display_address %></div>
-  <% end %>
-  <% if @organization.hiring? %>
-    <span id="label-hiring" class="label label-success pull-left status">Hiring</span>
-  <% end %>
-</div>
+<span class="big-text"><%= @organization.name %></span>
+<p><%= @organization.headline %></p>

--- a/app/views/organizations/_show_address.html.erb
+++ b/app/views/organizations/_show_address.html.erb
@@ -1,1 +1,1 @@
-<div class="pull-left"><%= display_address %></div>
+<p><%= display_address %></p>

--- a/app/views/organizations/_show_address.html.erb
+++ b/app/views/organizations/_show_address.html.erb
@@ -1,0 +1,1 @@
+<div class="pull-left"><%= display_address %></div>

--- a/app/views/organizations/_show_claimant.html.erb
+++ b/app/views/organizations/_show_claimant.html.erb
@@ -2,7 +2,4 @@
   <p class="claimant">
     This profile was claimed by: <%= link_to @organization.users.first.name, user_path(@organization.users.first) %>
   </p>
-  <% @organization.organization_user_roles.each do |role| %>
-    <%= role.name %>: <%= role.user.name %><br />
-  <% end %>
 <% end %>

--- a/app/views/organizations/_show_hiring.html.erb
+++ b/app/views/organizations/_show_hiring.html.erb
@@ -1,3 +1,4 @@
 <% if @organization.hiring? %>
   <span id="label-hiring" class="label label-success pull-left status">Hiring</span>
 <% end %>
+<br /><br />

--- a/app/views/organizations/_show_hiring.html.erb
+++ b/app/views/organizations/_show_hiring.html.erb
@@ -1,0 +1,3 @@
+<% if @organization.hiring? %>
+  <span id="label-hiring" class="label label-success pull-left status">Hiring</span>
+<% end %>

--- a/app/views/organizations/_show_profile_links.html.erb
+++ b/app/views/organizations/_show_profile_links.html.erb
@@ -1,14 +1,12 @@
-<div class="row">
-  <div class="col-sm-5">
-    <ul class="list-unstyled">
-      <li>
-        <span><%= link_to "Startup Genome", @organization.url if @organization.url.present? %></span>
-      </li>
-      <% @organization.profile_links.each do |profile_link| %> 
-        <li>
-          <%= link_to profile_link.name, profile_link.url %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
-</div>
+
+<ul class="list-unstyled">
+  <li>
+    <span><%= link_to "Startup Genome", @organization.url if @organization.url.present? %></span>
+  </li>
+  <% @organization.profile_links.each do |profile_link| %> 
+    <li>
+      <%= link_to profile_link.name, profile_link.url %>
+    </li>
+  <% end %>
+</ul>
+

--- a/app/views/organizations/_show_roles_form_header.html.erb
+++ b/app/views/organizations/_show_roles_form_header.html.erb
@@ -1,0 +1,9 @@
+<% if current_user.present? %>
+  <div class="alert alert-info">
+    <p>Are you affiliated with this company? Add your role:</p>
+    <%= form_tag add_role_path(@organization.id), method: :post, role: "form", class: "form-inline" do %>
+      <%= collection_select :role, :id, Role.all, :id, :name, {}, {class: "form-control"}%>
+      <%= submit_tag "Add Role", class: "btn btn-default" %>
+    <% end %>  
+  </div>
+<% end %>

--- a/app/views/organizations/_show_tags.html.erb
+++ b/app/views/organizations/_show_tags.html.erb
@@ -1,11 +1,9 @@
-  <div class="col-sm-8">
-    <div id="tags">
-      <div class="tag-list">
-        <% @organization.tags.each do |tag| %>
-          <span class="label label-primary tag pull-left">
-            <%= link_to tag.name, search_path(tag: {names: [tag.name]}) %>
-          </span>
-        <% end %>
-      </div>
-    </div>
+<div id="tags">
+  <div class="tag-list">
+    <% @organization.tags.each do |tag| %>
+      <span class="label label-primary tag pull-left">
+        <%= link_to tag.name, search_path(tag: {names: [tag.name]}) %>
+      </span>
+    <% end %>
   </div>
+</div>

--- a/app/views/organizations/_show_users.html.erb
+++ b/app/views/organizations/_show_users.html.erb
@@ -1,11 +1,16 @@
-  <div class="col-sm-8">
-    <div id="people">
-      <% @organization.users.each do |user| %>
-        <%= image_tag user.image %>
-        <%= link_to user.name, user_path(user) %>
-        <% if user.is_admin?(@organization) %>
-          (Admin) 
-        <% end %>
-      <% end %>
-    </div>
+<div class="row">
+  <div id="people">
+  <% @organization.organization_user_roles.each do |role| %>
+    <%= image_tag role.user.image %>
+    <%= role.name %>: <%= link_to role.user.name, user_path(role.user) %>
+  <% end %>
+</div>
+<div class="row">
+  <p>Are you affiliated with this company? Add your role:</p>
+  <div class="col-sm-4">
+    <%= form_tag add_role_path(@organization.id), method: :post, role: "form", class: "form-inline" do %>
+      <%= collection_select :role, :id, Role.all, :id, :name, {}, {class: "form-control"}%>
+      <%= submit_tag "Add Role", class: "btn btn-default" %>
+    <% end %>  
   </div>
+</div>

--- a/app/views/organizations/_show_users.html.erb
+++ b/app/views/organizations/_show_users.html.erb
@@ -1,16 +1,10 @@
-<div class="row">
-  <div id="people">
-  <% @organization.organization_user_roles.each do |role| %>
-    <%= image_tag role.user.image %>
-    <%= role.name %>: <%= link_to role.user.name, user_path(role.user) %>
+<h4>PEOPLE</h4>
+<% @organization.organization_user_roles.each do |role| %>
+  <div class="person pull-left">
+  <%= image_tag role.user.image, height: "50", class: "pull-left" %>
+  <%= role.name %><br /><%= link_to role.user.name, user_path(role.user) %>
+  <% if user_is_current_user?(role.user) || organization_admin_user? %>
+    <%= link_to '<span class="glyphicon glyphicon-remove"></span>'.html_safe, remove_role_path(@organization.id, role.id), method: :delete, class: "remove-role remove-role-org-page pull-right" %>
   <% end %>
-</div>
-<div class="row">
-  <p>Are you affiliated with this company? Add your role:</p>
-  <div class="col-sm-4">
-    <%= form_tag add_role_path(@organization.id), method: :post, role: "form", class: "form-inline" do %>
-      <%= collection_select :role, :id, Role.all, :id, :name, {}, {class: "form-control"}%>
-      <%= submit_tag "Add Role", class: "btn btn-default" %>
-    <% end %>  
   </div>
-</div>
+<% end %>

--- a/app/views/organizations/_show_users.html.erb
+++ b/app/views/organizations/_show_users.html.erb
@@ -1,0 +1,11 @@
+  <div class="col-sm-8">
+    <div id="people">
+      <% @organization.users.each do |user| %>
+        <%= image_tag user.image %>
+        <%= link_to user.name, user_path(user) %>
+        <% if user.is_admin?(@organization) %>
+          (Admin) 
+        <% end %>
+      <% end %>
+    </div>
+  </div>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -6,4 +6,6 @@
 <%= render "organizations/show_profile_links" if @organization.profile_links.any? %>
 <%= render "organizations/show_types" if @organization.types.any? %>
 <%= render "organizations/profile_description" if @organization.description? %>
+<%= render "organizations/show_users" if @organization.users.any? %>
 <%= render "organizations/show_claimant" if @organization.claimed? %>
+

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,11 +1,29 @@
-<%= render "organizations/claim_header" %>
-<br />
-<%= render "organizations/edit_mode" %>
-<%= render "organizations/profile_header" %>
-<%= render "organizations/show_tags" if @organization.tags.any? %> 
-<%= render "organizations/show_profile_links" if @organization.profile_links.any? %>
-<%= render "organizations/show_types" if @organization.types.any? %>
-<%= render "organizations/profile_description" if @organization.description? %>
-<%= render "organizations/show_users" if @organization.users.any? %>
-<%= render "organizations/show_claimant" if @organization.claimed? %>
+<div class="row">
+  <%= render "organizations/claim_header" %>
+</div>
+<div class="row">
+  <%= render "organizations/show_roles_form_header" %>
+</div>
+<div class="row">
+  <%= render "organizations/edit_mode" %>
+</div>
+<div class="row">
+  <div class="col-sm-4">
+    <%= render "organizations/image" %>
+    <%= render "organizations/show_address" if @organization.main_address.present? %>
+    <%= render "organizations/show_profile_links" if @organization.profile_links.any? %>
+  </div>
+  <div class="col-sm-8">
+    <%= render "organizations/profile_header" %>
+    <%= render "organizations/show_tags" if @organization.tags.any? %> 
+    <%= render "organizations/show_types" if @organization.types.any? %>
+    <%= render "organizations/profile_description" if @organization.description? %>
+    <%= render "organizations/show_users" if @organization.organization_user_roles.any? %>
+  </div>
+</div>
+<div class="row">
+  <div class="col-sm-12">
+    <%= render "organizations/show_claimant" if @organization.claimed? %>
+  </div>
+</div>
 

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -15,6 +15,7 @@
   </div>
   <div class="col-sm-8">
     <%= render "organizations/profile_header" %>
+    <%= render "organizations/show_hiring" if @organization.hiring? %>
     <%= render "organizations/show_tags" if @organization.tags.any? %> 
     <%= render "organizations/show_types" if @organization.types.any? %>
     <%= render "organizations/profile_description" if @organization.description? %>

--- a/app/views/users/_show_organizations.html.erb
+++ b/app/views/users/_show_organizations.html.erb
@@ -8,6 +8,17 @@
             <span class="pull-right"><%= link_to "Create New Organization", new_organization_path, class: "right" %></span>
           <% end %>
         </div>
+        <% @user.organizations.each do |organization| %>
+          <div class="role pull-left">
+            <% if organization.image.present? %>
+              <%= image_tag organization.image, height: "50", class: "pull-left" %>
+            <% else %>
+              <span class="wr-icon wr-icon-startup wr-icon-xl placeholder"></span>
+            <% end %>
+            <%= link_to organization.name, organization_path(organization) %><br />
+            Admin
+          </div>  
+        <% end %>
         <% @user.organization_user_roles.each do |role| %>
           <div class="role pull-left">
             <% if role.organization.image.present? %>
@@ -15,7 +26,7 @@
             <% else %>
               <span class="wr-icon wr-icon-startup wr-icon-xl placeholder"></span>
             <% end %>
-            <%= link_to role.organization.name, organization_path(role.organization) %>  
+            <%= link_to role.organization.name, organization_path(role.organization) %><br />
             <%= role.name %>      
           </div>  
         <% end %>

--- a/app/views/users/_show_organizations.html.erb
+++ b/app/views/users/_show_organizations.html.erb
@@ -8,15 +8,15 @@
             <span class="pull-right"><%= link_to "Create New Organization", new_organization_path, class: "right" %></span>
           <% end %>
         </div>
-        <% @user.organizations.each do |org| %>
-          <div>
-            <span class="wr-icon wr-icon-startup wr-icon-xl placeholder"></span>
-            <%= link_to org.name, organization_path(org) %>
-              <% if user_is_current_user? %>
-                <% current_user.current_roles(org).each do |role| %>
-                (<%= role.name %>)
-              <% end %>
+        <% @user.organization_user_roles.each do |role| %>
+          <div class="role pull-left">
+            <% if role.organization.image.present? %>
+              <%= image_tag role.organization.image, height: "50", class: "pull-left" %>
+            <% else %>
+              <span class="wr-icon wr-icon-startup wr-icon-xl placeholder"></span>
             <% end %>
+            <%= link_to role.organization.name, organization_path(role.organization) %>  
+            <%= role.name %>      
           </div>  
         <% end %>
       </div>

--- a/db/migrate/20140624004504_add_admin_id_to_organizations.rb
+++ b/db/migrate/20140624004504_add_admin_id_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddAdminIdToOrganizations < ActiveRecord::Migration
+  def change
+    add_column :organizations, :admin_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140620172749) do
+ActiveRecord::Schema.define(version: 20140624004504) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 20140620172749) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "image"
+    t.integer  "admin_id"
   end
 
   add_index "organizations", ["slug"], name: "index_organizations_on_slug", unique: true, using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-Role.create!([{name: 'Employee'}, {name: 'Founder'}])
+Role.create!([{name: 'Employee'}, {name: 'Founder'}, {name: 'Freelancer/Contractor'}, {name: 'Board Member'}, {name: 'Investor'}, {name: 'Service Provider'}, {name: 'Consultant'}, {name: 'Advisor'}, {name: 'Client'}, {name: 'User'}])
 
 Type.create!([
   {name: "Startups"},

--- a/features/authentication.feature
+++ b/features/authentication.feature
@@ -8,5 +8,5 @@ Feature: Authentication
   Scenario: Signing into my account
     Given I login with "Twitter"
     And I submit an email address
+    And I edit my profile page
     Then I should be on the user profile page for "J C"
-    And my email address should be present

--- a/features/step_definitions/activity_stream_steps.rb
+++ b/features/step_definitions/activity_stream_steps.rb
@@ -3,9 +3,11 @@ When(/^I go to the activity stream page$/) do
 end
 
 Then(/^I should see the "(.*?)" activity$/) do |activity|
+  sleep 1
   expect(page).to have_content(activity)
 end
 
 Then(/^I should see the claim activity$/) do
+  sleep 1
   expect(page).to have_content("J C claimed Brewhouse")
 end

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -21,6 +21,3 @@ Given(/^I submit an email address$/) do
   click_button "Submit"
 end
 
-Then(/^my email address should be present$/) do
-  expect(page).to have_content("jncoops7@live.com")
-end

--- a/features/step_definitions/organizations/profile_steps.rb
+++ b/features/step_definitions/organizations/profile_steps.rb
@@ -21,6 +21,7 @@ When(/^I visit the profile page$/) do
 end
 
 Then(/^I should see the organization's profile$/) do
+  sleep 1
   expect(page).to have_content(@organization.name)
 end
 
@@ -39,6 +40,7 @@ Then(/^I should be the organization's admin user$/) do
 end
 
 Then(/^I should see the organization on my profile$/) do
+  sleep 1
   page.should have_content(@organization.name)
 end
 
@@ -76,10 +78,12 @@ When(/^I uncheck the hiring box$/) do
 end
 
 Then(/^the organization should be hiring$/) do
+  sleep 1
   page.should have_css('#label-hiring')
 end
 
 Then(/^the organization should not be hiring$/) do
+  sleep 1
   page.should_not have_css('#label-hiring')
 end
 

--- a/features/step_definitions/organizations/tags_steps.rb
+++ b/features/step_definitions/organizations/tags_steps.rb
@@ -8,7 +8,6 @@ When(/^I remove the tag$/) do
   within(".tag-list") do
     first("a.remove-tag").click
   end
-  sleep 2
 end
 
 Then(/^the new tag "(.*?)" should be applied to my organization$/) do |tag_name|


### PR DESCRIPTION
- A signed in user can go to an organization's public profile and add and/or remove roles from the organization regardless of whether the organization has been claimed or not (like a wiki)
- The organization admin user can remove any users that add themselves
- Associated organizations are shown on a user's public profile
- Various style and refactoring changes

TODO:
- Allow admin user to add users
- Allow users to add organizations from his or her profile
- Send admin user an email when a user associates him or herself with an organization
